### PR TITLE
Add uvx remote execution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A command-line utility to manage MLX models between your Hugging Face cache and 
 
 ## Installation
 
+You can skip this if you are using uvx remote execution (see below).
+
 1. Clone this repository:
 ```bash
 git clone https://github.com/ivanfioravanti/lmstudio_hf.git
@@ -30,6 +32,11 @@ Run the script using Python:
 
 ```bash
 python lmstudio_hf.py
+```
+
+Alternatively, you can use uvx remote execution:
+```bash
+uvx git+https://github.com/ivanfioravanti/lmstudio_hf
 ```
 
 ### Navigation Controls

--- a/lmstudio_hf.py
+++ b/lmstudio_hf.py
@@ -131,6 +131,9 @@ def manage_models():
             
             print(f"Imported {model_name} (symlinked files)")
 
-if __name__ == "__main__":
+def main():
+    """Entry point for uvx execution"""
     manage_models()
 
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lmstudio-hf"
+version = "1.0.0"
+description = "A command-line utility to manage MLX models between your Hugging Face cache and LM Studio"
+authors = [{name = "Ivan Fioravanti"}]
+requires-python = ">=3.8"
+dependencies = []
+
+[project.scripts]
+lmstudio-hf = "lmstudio_hf:main"


### PR DESCRIPTION
This PR adds support for uvx remote execution to the lmstudio_hf tool.

Changes made:
1. Added pyproject.toml with build system configuration
2. Wrapped main logic in a function to support uvx entry point
3. Updated README with uvx execution instructions

You can test this using:
```
uvx git+https://github.com/trieloff/lmstudio_hf
```
