### PR TITLE
Add support for all Hugging Face model types...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # LM Studio - Hugging Face Model Manager
 
-A command-line utility to manage MLX models between your Hugging Face cache and LM Studio. This tool makes it easy to import and manage models you've downloaded from Hugging Face into LM Studio.
+A command-line utility to manage models between your Hugging Face cache and LM Studio. This tool makes it easy to import and manage any models you've downloaded from Hugging Face into LM Studio.
 
 ## Features
 
 - Interactive model selection interface with keyboard navigation
-- Automatic detection of MLX models in your Hugging Face cache
+- Automatic detection of all models in your Hugging Face cache
 - Smart handling of model imports via symbolic links
-- Support for model replacement and removal
+- Support for model removal and re-import
 - Terminal-based UI with scrolling for large model lists
+- Shows model type (e.g., llama, bert, gpt2) for easy identification
+- Already imported models are pre-selected and clearly marked
 
 ## Prerequisites
 
@@ -41,20 +43,23 @@ python lmstudio_hf.py
 
 ## How It Works
 
-1. The tool scans your Hugging Face cache directory (`~/.cache/huggingface` by default)
-2. Identifies MLX-compatible models (excluding specific types like Whisper, LLaVA, etc.)
+1. The tool scans your Hugging Face cache directory (checks `HF_HOME`, `XDG_CACHE_HOME/huggingface`, or `~/.cache/huggingface`)
+2. Identifies all downloaded models with valid `config.json` files
 3. Creates symbolic links in the LM Studio models directory (`~/.cache/lm-studio/models`)
-4. Allows for easy management of existing imports
+4. Shows model type and import status for each model
+5. Pre-selects already imported models for easy management
 
 ## Environment Variables
 
-- `HF_HOME`: Optional. Set this to customize your Hugging Face cache location.
+- `HF_HOME`: Optional. Set this to customize your Hugging Face cache location (highest priority)
+- `XDG_CACHE_HOME`: Optional. If set, the tool will look for models in `$XDG_CACHE_HOME/huggingface`
 
 ## Notes
 
 - Models are imported using symbolic links to save disk space
-- Already imported models are marked in the selection interface
-- Selecting an already imported model will remove it from LM Studio
+- Already imported models are marked with "(already imported)" and pre-selected
+- Deselecting an already imported model and confirming will remove it from LM Studio
+- Model types are displayed in parentheses (e.g., `(llama)`, `(bert)`, `(gpt2)`)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
  - Removed MLX-only filtering to support all Hugging Face model types
  - Added XDG_CACHE_HOME environment variable support for flexible cache locations  
  - Pre-select already imported models in the UI for better user experience

## Changes
  - Modified model detection to find all models with valid config.json (not just mlx-community)
  - Added cache directory priority: HF_HOME > XDG_CACHE_HOME/huggingface > ~/.cache/huggingface
  - Already imported models are now pre-selected by default in the selection interface
  - Updated README to reflect all changes and remove MLX-specific references
  - Model names now include the full organization/model path"