### PR TITLE
 Add support for all Hugging Face model types with improved import management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # LM Studio - Hugging Face Model Manager
 
-A command-line utility to manage MLX models between your Hugging Face cache and LM Studio. This tool makes it easy to import and manage models you've downloaded from Hugging Face into LM Studio.
+A command-line utility to manage models between your Hugging Face cache and LM Studio. This tool makes it easy to import and manage any models you've downloaded from Hugging Face into LM Studio.
 
 ## Features
 
 - Interactive model selection interface with keyboard navigation
-- Automatic detection of MLX models in your Hugging Face cache
+- Automatic detection of all models in your Hugging Face cache
 - Smart handling of model imports via symbolic links
-- Support for model replacement and removal
+- Support for model removal and re-import
 - Terminal-based UI with scrolling for large model lists
+- Shows model type (e.g., llama, bert, gpt2) for easy identification
+- Already imported models are pre-selected and clearly marked
 
 ## Prerequisites
 
@@ -41,20 +43,23 @@ python lmstudio_hf.py
 
 ## How It Works
 
-1. The tool scans your Hugging Face cache directory (`~/.cache/huggingface` by default)
-2. Identifies MLX-compatible models (excluding specific types like Whisper, LLaVA, etc.)
+1. The tool scans your Hugging Face cache directory (checks `HF_HOME`, `XDG_CACHE_HOME/huggingface`, or `~/.cache/huggingface`)
+2. Identifies all downloaded models with valid `config.json` files
 3. Creates symbolic links in the LM Studio models directory (`~/.cache/lm-studio/models`)
-4. Allows for easy management of existing imports
+4. Shows model type and import status for each model
+5. Pre-selects already imported models for easy management
 
 ## Environment Variables
 
-- `HF_HOME`: Optional. Set this to customize your Hugging Face cache location.
+- `HF_HOME`: Optional. Set this to customize your Hugging Face cache location (highest priority)
+- `XDG_CACHE_HOME`: Optional. If set, the tool will look for models in `$XDG_CACHE_HOME/huggingface`
 
 ## Notes
 
 - Models are imported using symbolic links to save disk space
-- Already imported models are marked in the selection interface
-- Selecting an already imported model will remove it from LM Studio
+- Already imported models are marked with "(already imported)" and pre-selected
+- Deselecting an already imported model and confirming will remove it from LM Studio
+- Model types are displayed in parentheses (e.g., `(llama)`, `(bert)`, `(gpt2)`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ Run the script using Python:
 python lmstudio_hf.py
 ```
 
+### Using Custom Directories
+
+You can customize the directories using environment variables:
+
+```bash
+# Custom Hugging Face cache directory
+export HF_HOME="/path/to/huggingface/cache"
+python lmstudio_hf.py
+
+# Custom LM Studio models directory
+export LMSTUDIO_HOME="/path/to/lmstudio/models"
+python lmstudio_hf.py
+
+# Use XDG cache directory
+export XDG_CACHE_HOME="/path/to/cache"
+python lmstudio_hf.py
+
+# Combine multiple environment variables
+export HF_HOME="/custom/hf/cache"
+export LMSTUDIO_HOME="/custom/lmstudio/models"
+python lmstudio_hf.py
+```
+
 ### Navigation Controls
 
 - ↑/↓ arrows: Navigate through the model list
@@ -53,6 +76,7 @@ python lmstudio_hf.py
 
 - `HF_HOME`: Optional. Set this to customize your Hugging Face cache location (highest priority)
 - `XDG_CACHE_HOME`: Optional. If set, the tool will look for models in `$XDG_CACHE_HOME/huggingface`
+- `LMSTUDIO_HOME`: Optional. Set this to customize your LM Studio models directory (default: `~/.cache/lm-studio/models`)
 
 ## Notes
 

--- a/lmstudio_hf.py
+++ b/lmstudio_hf.py
@@ -61,7 +61,11 @@ def manage_models():
     else:
         cache_dir = Path(os.path.expanduser("~/.cache/huggingface"))
     
-    lm_studio_dir = Path(os.path.expanduser("~/.cache/lm-studio/models"))
+    # Allow custom LM Studio directory via environment variable
+    if "LMSTUDIO_HOME" in os.environ:
+        lm_studio_dir = Path(os.environ["LMSTUDIO_HOME"])
+    else:
+        lm_studio_dir = Path(os.path.expanduser("~/.cache/lm-studio/models"))
     
     found_models = set()
     for root, dirs, _ in os.walk(cache_dir):

--- a/lmstudio_hf.py
+++ b/lmstudio_hf.py
@@ -5,8 +5,8 @@ import sys
 import shutil
 
 def select_models(model_choices):
-    # Pre-select already imported models
-    selected = [choice[2] for choice in model_choices]  # choice[2] is is_imported
+    # Don't pre-select any models
+    selected = [False] * len(model_choices)
     idx = 0
     window_size = os.get_terminal_size().lines - 5
     
@@ -18,8 +18,15 @@ def select_models(model_choices):
         window_end = min(window_start + window_size, len(model_choices))
 
         for i in range(window_start, window_end):
-            display_name, _, _, _ = model_choices[i]
-            print(f"{'>' if i == idx else ' '} {'◉' if selected[i] else '○'} {display_name}")
+            display_name, _, is_imported, _, _ = model_choices[i]
+            # Use red color for already imported models
+            if is_imported:
+                color = "\033[31m"  # Red
+                reset = "\033[0m"   # Reset color
+                display_text = f"{color}{display_name}{reset}"
+            else:
+                display_text = display_name
+            print(f"{'>' if i == idx else ' '} {'◉' if selected[i] else '○'} {display_text}")
 
         key = get_key()
         if key == "\x1b[A":  # Up arrow
@@ -68,58 +75,116 @@ def manage_models():
         lm_studio_dir = Path(os.path.expanduser("~/.cache/lm-studio/models"))
     
     found_models = set()
-    for root, dirs, _ in os.walk(cache_dir):
-        for d in dirs:
-            if "--" in d:  # Check for Hugging Face naming pattern (org--model)
-                model_dir = Path(root) / d
+    
+    # Look in hub directory if it exists
+    hub_dir = cache_dir / "hub"
+    search_dirs = [hub_dir] if hub_dir.exists() else []
+    search_dirs.append(cache_dir)
+    
+    for search_dir in search_dirs:
+        for root, dirs, _ in os.walk(search_dir):
+            for d in dirs:
+                # Skip datasets directories
+                if d.startswith("datasets--") or "datasets" in Path(root).parts:
+                    continue
+                    
+                # Check for models--org--name pattern
+                if d.startswith("models--") and "--" in d:
+                    model_dir = Path(root) / d
+                    # Extract model name from models--org--name format
+                    parts = d.replace("models--", "").split("--")
+                    model_name = "/".join(parts)
+                elif "--" in d:  # Check for other HF naming patterns
+                    model_dir = Path(root) / d
+                    parts = d.split("--")
+                    model_name = "/".join(parts)
+                else:
+                    continue
+                
+                # Look for snapshots directory
                 snapshots_dir = model_dir / "snapshots"
                 if not snapshots_dir.exists():
                     continue
 
-                # Search for config.json in any subfolder under snapshots
-                config_found = False
+                # Search for snapshots - with or without config.json
+                model_type = "unknown"
                 snapshot_path = None
-                for config_root, _, config_files in os.walk(snapshots_dir):
-                    if "config.json" in config_files:
-                        config_path = Path(config_root) / "config.json"
-                        try:
-                            with open(config_path) as f:
-                                config = json.load(f)
-                                model_type = config.get("model_type", "unknown").lower()
-                                config_found = True
-                                snapshot_path = Path(config_root)
-                                break
-                        except (json.JSONDecodeError, FileNotFoundError):
-                            continue
-
-                if not config_found or not snapshot_path:
-                    continue
+                
+                # Walk through snapshots directory
+                for config_root, snapshot_dirs, config_files in os.walk(snapshots_dir):
+                    # Skip the snapshots directory itself, look in subdirectories
+                    if config_root == str(snapshots_dir) and snapshot_dirs:
+                        continue
                     
-                parts = d.split("--")
-                model_name = "/".join(parts)  # Keep full name including organization
-                if model_name:
-                    # Store model_type, model_name, and snapshot_path
+                    # If we found files in a snapshot subdirectory, this is a valid model
+                    if config_files or snapshot_dirs:
+                        snapshot_path = Path(config_root)
+                        
+                        # Try to find config.json for model type
+                        if "config.json" in config_files:
+                            config_path = Path(config_root) / "config.json"
+                            try:
+                                with open(config_path) as f:
+                                    config = json.load(f)
+                                    model_type = config.get("model_type", "unknown").lower()
+                            except (json.JSONDecodeError, FileNotFoundError):
+                                pass
+                        break
+
+                if snapshot_path and model_name:
+                    # Store model even if no config.json was found
                     found_models.add((model_type, model_name, snapshot_path))
 
     if not found_models:
         print("No models found in Hugging Face cache")
         return
 
+    # First, scan all existing models in LM Studio directory recursively
+    existing_lm_models = {}  # Maps normalized names to actual paths
+    if lm_studio_dir.exists():
+        # Check for org/model structure (subdirectories)
+        for org_dir in lm_studio_dir.iterdir():
+            if org_dir.is_dir():
+                # Check if this is an org directory with model subdirectories
+                has_subdirs = False
+                try:
+                    for model_dir in org_dir.iterdir():
+                        if model_dir.is_dir():
+                            has_subdirs = True
+                            # This is org/model format
+                            model_name = f"{org_dir.name}/{model_dir.name}"
+                            existing_lm_models[model_name] = model_dir
+                except:
+                    pass  # Handle permission errors
+                
+                # If no subdirectories, this might be a direct model directory
+                if not has_subdirs:
+                    existing_lm_models[org_dir.name] = org_dir
+    
     # Create list of models with their current import status
     model_choices = []
     for model_type, model, snapshot_path in sorted(found_models):
-        target_path = lm_studio_dir / f"{model}"
-        is_imported = target_path.exists()
+        is_imported = False
+        actual_target_path = None
+        
+        # Check for the exact model path as it would be created
+        if model in existing_lm_models:
+            is_imported = True
+            actual_target_path = existing_lm_models[model]
+        
+        # If not found, use default path for new imports or removals
+        if actual_target_path is None:
+            actual_target_path = lm_studio_dir / model
+            
         status = " (already imported)" if is_imported else ""
         display_name = f"({model_type}) {model}{status}"
-        model_choices.append((display_name, model, is_imported, snapshot_path))
+        model_choices.append((display_name, model, is_imported, snapshot_path, actual_target_path))
 
     # Show interactive selection menu
     selected = select_models(model_choices)
     print("\nImporting models...\n")
     
-    for display_name, model_name, is_imported, snapshot_path in selected:
-        target_path = lm_studio_dir / f"{model_name}"
+    for display_name, model_name, is_imported, snapshot_path, target_path in selected:
         
         if is_imported:
             # Remove existing directory or symlink


### PR DESCRIPTION
 ## Summary
This PR extends the tool to support ALL Hugging Face models (not just MLX) and improves the import management experience with better visual feedback.

  ## Major Changes

  ### 1. Universal Model Support
  - Removed MLX-only filtering - now finds all Hugging Face model types
  - Added support for models without config.json files
  - Excludes dataset directories to keep the model list clean
  - Supports both `hub/` and direct cache directory structures

  ### 2. Enhanced Directory Detection
  - Added support for `XDG_CACHE_HOME` environment variable
  - Added support for `LMSTUDIO_HOME` environment variable for custom LM Studio paths
  - Priority order: `HF_HOME` > `XDG_CACHE_HOME/huggingface` > `~/.cache/huggingface`

  ### 3. Improved User Experience
  - Already imported models are now shown in red color for clear visual distinction
  - Maintains "(already imported)" text as additional indicator

  ## Environment Variables
  - `HF_HOME`: Custom Hugging Face cache location (highest priority)
  - `XDG_CACHE_HOME`: Standard XDG cache directory support
  - `LMSTUDIO_HOME`: Custom LM Studio models directory